### PR TITLE
fix: code checks stairsUp twice, check stairsDown

### DIFF
--- a/src/dungeon.js
+++ b/src/dungeon.js
@@ -32,7 +32,7 @@ export default class Dungeon {
           for (let x = 0; x < r.size.x; x++) {
             if (r.tiles[y][x] === tiles.stairsUp) {
               result.up = { x: r.pos.x + x, y: r.pos.y + y };
-            } else if (r.tiles[y][x] === tiles.stairsUp) {
+            } else if (r.tiles[y][x] === tiles.stairsDown) {
               result.down = { x: r.pos.x + x, y: r.pos.y + y };
             }
           }


### PR DESCRIPTION
I'm using your dungeon generator in a project and was not getting all the stairs returned from getStairs. I noticed it wasn't checking stairsDown. In my project I just needed your Dungeon class and the supporting Room/Tiles so I just copy/pasted (fixed that bug) and converted them to TypeScript. It's working great thanks. I'll add credit. Thanks again!